### PR TITLE
Split render element transform into components

### DIFF
--- a/src/main/scala/engine/render/renderer/render_element/NGonRenderElement.scala
+++ b/src/main/scala/engine/render/renderer/render_element/NGonRenderElement.scala
@@ -4,13 +4,16 @@ import engine.math.{pi, cos, sin}
 import engine.render.renderer.RenderData
 import engine.render.Color
 import engine.math.Matrix3
+import engine.math.Vector2
 
 final case class NGonRenderElement(
     radius: Float,
     segments: Int = 64,
     var layer: Float = 0,
     var color: Color = Color.WHITE,
-    var transform: Matrix3 = Matrix3.IDENTITY
+    var position: Vector2 = Vector2.zero,
+    var rotation: Float = 0,
+    var scale: Vector2 = Vector2.one
 ) extends RenderElement {
 
   // Throw exceptions if arguments are invalid
@@ -27,7 +30,11 @@ final case class NGonRenderElement(
       indices = indices,
       layer = layer,
       color = color,
-      transform = transform
+      transform = Matrix3.transform(
+        position,
+        rotation,
+        scale
+      )
     )
   }
 

--- a/src/main/scala/engine/render/renderer/render_element/PolygonRenderElement.scala
+++ b/src/main/scala/engine/render/renderer/render_element/PolygonRenderElement.scala
@@ -11,7 +11,9 @@ final case class PolygonRenderElement(
     var points: Vector[Vector2],
     var layer: Float = 0,
     var color: Color = Color.WHITE,
-    var transform: Matrix3 = Matrix3.IDENTITY
+    var position: Vector2 = Vector2.zero,
+    var rotation: Float = 0,
+    var scale: Vector2 = Vector2.one
 ) extends RenderElement {
 
   // Throw exceptions if arguments are invalid
@@ -32,7 +34,11 @@ final case class PolygonRenderElement(
       indices = indices,
       layer = layer,
       color = color,
-      transform = transform
+      transform = Matrix3.transform(
+        position,
+        rotation,
+        scale
+      )
     )
   }
 }

--- a/src/main/scala/engine/render/renderer/render_element/PolylineRenderElement.scala
+++ b/src/main/scala/engine/render/renderer/render_element/PolylineRenderElement.scala
@@ -13,7 +13,9 @@ final case class PolylineRenderElement(
     width: Float = 1,
     var layer: Float = 0,
     var color: Color = Color.WHITE,
-    var transform: Matrix3 = Matrix3.IDENTITY
+    var position: Vector2 = Vector2.zero,
+    var rotation: Float = 0,
+    var scale: Vector2 = Vector2.one
 ) extends RenderElement {
 
   // Throw exceptions if arguments are invalid
@@ -33,7 +35,11 @@ final case class PolylineRenderElement(
       indices = indices,
       layer = layer,
       color = color,
-      transform = transform
+      transform = Matrix3.transform(
+        position,
+        rotation,
+        scale
+      )
     )
   }
 

--- a/src/main/scala/general/Main.scala
+++ b/src/main/scala/general/Main.scala
@@ -57,8 +57,7 @@ object MyGame extends Game {
       Vector2(0, .2)
     ).map(v => Vector2(v.x - .5, v.y - .5)),
     layer = 0,
-    color = Color.WHITE,
-    transform = Matrix3.IDENTITY
+    color = Color.WHITE
   )
   val iris = NGonRenderElement(
     radius = 0.5f,
@@ -184,12 +183,10 @@ object MyGame extends Game {
       sin(2f * Time.current) * .5f + .5f,
       sin(3f * Time.current) * .5f + .5f
     )
-    pupil.transform = Matrix3.transform(
-      translation = Vector2(
-        (input.mousePosition.x - window.resolution.width / 2) / window.resolution.width,
-        -(input.mousePosition.y - window.resolution.height / 2) / window.resolution.height
-      ) * 0.17f
-    )
+    pupil.position = Vector2(
+      (input.mousePosition.x - window.resolution.width / 2) / window.resolution.width,
+      -(input.mousePosition.y - window.resolution.height / 2) / window.resolution.height
+    ) * 0.17f
 
     renderer.render(
       List(


### PR DESCRIPTION
All classes that extend `RenderElement` in `renderer.render_element` had their `transform` constructor parameter split into 3 parameters for ease of use, n.l. `position`, `rotation` and `scale`.